### PR TITLE
Add Zapier trigger that fires when Documents are updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const docCreate = require('./creates/doc');
 const docTrigger = require('./triggers/doc');
+const docUpdatedTrigger = require('./triggers/docUpdated');
 const collectionTrigger = require('./triggers/collection');
 const authentication = require('./authentication');
 
@@ -48,7 +49,8 @@ const App = {
   // If you want your trigger to show up, you better include it here!
   triggers: {
     [collectionTrigger.key]: collectionTrigger,
-    [docTrigger.key]: docTrigger
+    [docTrigger.key]: docTrigger,
+    [docUpdatedTrigger.key]: docUpdatedTrigger
   },
 
   // If you want your searches to show up, you better include it here!

--- a/triggers/docUpdated.js
+++ b/triggers/docUpdated.js
@@ -16,9 +16,9 @@ const listDocuments = (z, bundle) => {
     .then(response => JSON.parse(response.content))
     .then(content => content.data)
     .then(items => items.map((item) => {
-      const documentId = item.id;
-      const documentRevision = item.revision;
-      item.id = documentId + '-' + documentRevision;
+      item.documentId = item.id;
+      item.revision;
+      item.id = item.documentId + '-' + item.documentRevision;
       return item;
     }));
 };

--- a/triggers/docUpdated.js
+++ b/triggers/docUpdated.js
@@ -1,0 +1,40 @@
+const sample = require("../samples/doc.json");
+
+const listDocuments = (z, bundle) => {
+  const responsePromise = z.request({
+    method: 'GET',
+    url: `https://app.getoutline.com/api/documents.list`,
+    params: {
+      sort: "updatedAt",
+      direction: "DESC",
+      collectionId: bundle.inputData.collectionId,
+      limit: 20,
+      offset: 20 * bundle.meta.page
+    }
+  });
+  return responsePromise
+    .then(response => JSON.parse(response.content))
+    .then(content => content.data)
+    .then(items => items.map((item) => {
+      const documentId = item.id;
+      const documentRevision = item.revision;
+      item.id = documentId + '-' + documentRevision;
+      return item;
+    }));
+};
+
+module.exports = {
+  key: 'docUpdated',
+  noun: 'Document',
+  display: {
+    label: 'Updated Document',
+    description: 'Triggers when a document is updated.'
+  },
+  operation: {
+    inputFields: [
+      { key: 'collectionId', label: 'Collection', dynamic: 'collection.id.name' },
+    ],
+    perform: listDocuments,
+    sample
+  }
+};

--- a/triggers/docUpdated.js
+++ b/triggers/docUpdated.js
@@ -17,8 +17,7 @@ const listDocuments = (z, bundle) => {
     .then(content => content.data)
     .then(items => items.map((item) => {
       item.documentId = item.id;
-      item.revision;
-      item.id = item.documentId + '-' + item.documentRevision;
+      item.id = item.documentId + '-' + item.revision;
       return item;
     }));
 };


### PR DESCRIPTION
@tommoor I haven't tested this yet — just wondering if you'd be interested in a PR like this before I spend more time on it.

This is just a copy of the original `document` trigger with a synthetic compound `id` that includes the document's `revision` as a suffix. The Zapier docs on "update triggers" are a bit bare but I believe this is how it works.

My one concern is that if a single Document is updated multiple times (i.e. multiple Revisions are created) in quick succession (i.e. within the polling interval), the Zap will trigger once for each of them. I suppose this is intended behavior on the Zapier platform.